### PR TITLE
Add talent.io company

### DIFF
--- a/frenchrubyshops.csv
+++ b/frenchrubyshops.csv
@@ -62,6 +62,7 @@ SociAddict,http://www.sociaddict.com/,agency,Paris
 Studio HB,http://www.studio-hb.com/,agency,Lyon
 Studio Melipone,http://www.studiomelipone.eu/,agency,Paris
 Synbioz,https://www.synbioz.com/,agency,"Lille, Nantes, Paris"
+talent.io,https://www.talent.io,product,"Paris, Berlin, London"
 Teezily,http://teezily.com/,product,Paris
 Tilkee,http://www.tilkee.fr,product,Lyon
 Tincy,http://www.tinci.fr/,agency,Paris


### PR DESCRIPTION
Please note that "talent.io" is our trademark, the first letter is not capitalized, this is on purpose. 

Thank you !
