### PR TITLE
Lita, Getaround, Samboat, Click2Buy, and https

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Please respect the following conventions:
 * Respect the CSV format (no space after comma) 
 * Category should be in lowercase
 * Companies are sorted by alphabetical name
-* Respect naming for cities already listed: `Saint-Etienne` and not `St Etienne` or `Saint Etienne`
+* Respect naming for cities already listed: `Saint-Étienne` and not `St Étienne` or `Saint Étienne`
 
-Available categories: `agency, bootcamp, editor, product`
+Available categories: `agency, bootcamp, editor, product`.
 
 Categories are not set in stone, open an issue if you want to add one.
 

--- a/frenchrubyshops.csv
+++ b/frenchrubyshops.csv
@@ -1,99 +1,99 @@
 Company,Website,Category,City
-9troisquarts,http://www.9troisquarts.com/,agency,Roubaix
-A Line,https://www.aline.work/,product,Paris
-Adomik,http://www.adomik.com/,product,Paris
-af83,http://af83.com/,agency,Paris
+9troisquarts,https://www.9troisquarts.com/,agency,Roubaix
+A Line,https://aline.work/,product,Paris
+Adomik,https://www.adomik.com/,product,Paris
+af83,https://af83.com/,agency,Paris
 Agence Cosmic,http://agencecosmic.com/,agency,Paris
-Agorize,http://www.agorize.com/,product,Paris
+Agorize,https://www.agorize.com/fr,product,Paris
 Aircall,https://aircall.io/,product,Paris
 Algolia,https://www.algolia.com/,product,Paris
-Alpine Lab,http://www.alpine-lab.com/,agency,Lyon
+Alpine Lab,https://www.alpine-lab.com/,agency,Lyon
 Appaloosa Store,https://www.appaloosa-store.com/,product,Paris
-Applidium,http://applidium.com/,agency,"Paris, Lyon"
+Applidium,https://applidium.com/,agency,"Paris, Lyon"
 Atnos,https://atnos.com/,agency,Castelnaudary
-Augment,http://www.augment.com/,product,Paris
-Boaterfly,http://www.boaterfly.com/,product,Paris
-Brand and Celebrities,http://www.brandandcelebrities.com,product,Paris
+Augment,https://www.augment.com/,product,Paris
+Brand and Celebrities,https://www.brandandcelebrities.com/,product,Paris
 Capsens,https://agence.capsens.eu/,product,Paris
 Captain Contrat,https://www.captaincontrat.com/,product,Paris
 Captive,https://captive.fr/,agency,Paris
 Cheerz,https://www.cheerz.com/,product,Paris
-Clic2Buy,http://www.clic2buy.com/,product,Lille
+Clic2Buy,https://www.click2buy.com/,product,Lille
 Codeur,https://www.codeur.com,product,Remote
 Coinhouse,https://www.coinhouse.com/,product,Paris
-Colisweb,http://www.colisweb.com/,product,Lille
+Colisweb,https://www.colisweb.com/fr,product,Lille
 Cults.,https://cults3d.com/,product,Paris
 Deligreens,https://www.deligreens.com/,product,Lyon
 deliver.ee,https://www.deliver.ee/,product,Paris
-Dernier Cri,http://derniercri.io,agency,"Lille, Paris"
+Dernier Cri,https://derniercri.io,agency,"Lille, Paris"
 Destygo,https://www.destygo.com/,product,Paris
 Dexem,https://www.dexem.com/,product,Rennes
 Diduenjoy,http://www.diduenjoy.com/fr/,product,Paris
-Dimelo,http://www.dimelo.com/,product,Paris
+Dimelo,https://www.dimelo.com/,product,Paris
 Doctolib,https://www.doctolib.fr/,product,"Paris, Berlin"
 Doumit,http://www.doum.it,agency,Lille
-Drivy,https://www.drivy.com/,product,Paris
 ecov,https://www.ecov.fr/,product,Nantes
-Effilab,http://www.effilab.com/,product,Boulogne-Billancourt
-Effy,http://www.effy.fr/,product,Paris
+Effilab,https://www.effilab.com/,product,Boulogne-Billancourt
+Effy,https://www.effy.fr/,product,Paris
 Ekimetrics,https://www.ekimetrics.com/,product,Paris
-Ekylibre,http://ekylibre.com/,product,Pessac
+Ekylibre,https://ekylibre.com/,product,Pessac
 Email Hunter,https://emailhunter.co/,product,Lyon
 En Voiture Simone,https://www.envoituresimone.com/,product,Paris
 Epices Énergie,http://www.epices-energie.fr/,product,Lyon
 Epopia,https://www.epopia.com/,product,Strasbourg
 Famest,http://www.famest.co/,product,Paris
-Faveod,http://www.faveod.com/,product,Paris
+Faveod,https://faveod.com/,product,Paris
 FidMarques,https://www.fidmarques.com/,product,Paris
 Fidzup,http://www.fidzup.com/,product,Clichy
 Fizzer,https://www.fizzer.com/,product,Dives-sur-Mer
 Flatlooker,https://www.flatlooker.com/,product,Paris
 Frizbiz,https://www.frizbiz.com/,product,Lille
+Getaround,https://fr.getaround.com/,product,Paris
 Happydemics,https://happydemics.com/,product,Paris
 HAVR, https://www.havr.io/,product,Compiègne
-Hi Duty Free,http://hidutyfree.com/,product,Lille
+Hi Duty Free,https://www.hidutyfree.com/,product,Lille
 Hosman,https://www.hosman.co/,product,Paris
-Hospimedia,http://www.hospimedia.fr/,product,Lille
-Hostnfly,http://hostnfly.com,product,Paris
+Hospimedia,https://www.hospimedia.fr/,product,Lille
+Hostnfly,https://www.hostnfly.com,product,Paris
 Idol,https://idol.io/,product,Paris
 Ifeelgoods,https://www.ifeelgoods.com/,product,Paris
 ilek,https://www.ilek.fr/,product,Toulouse
 iMenlo,http://www.imenlo.com,agency,Paris
-Impala Webstudio,http://www.impala-webstudio.fr/,agency,Lille
+Impala Webstudio,https://www.impala-webstudio.fr/,agency,Lille
 In The Memory,https://www.inthememory.com/,product,Paris
 Inch,https://inch.fr/,product,Saint-Ouen
 Javelo,https://javelo.io/,product,Paris
-Je Rêve d'une Maison,http://www.jerevedunemaison.com/,product,Paris
-JobTeaser.com,http://www.jobteaser.com/fr,product,Paris
+Je Rêve d'une Maison,https://www.jerevedunemaison.com/,product,Paris
+JobTeaser.com,https://www.jobteaser.com/fr,product,Paris
 Kactus,https://www.kactus.com/,product,Paris
 Kerala Ventures,https://www.kerala.vc/,product,Paris
-Key-Live,http://www.keley-live.com/,agency,Paris
+Key-Live,https://www.keley-live.com/,agency,Paris
 Keycoopt,https://www.keycoopt.com/,product,Lille
-KissKissBankBank,http://www.kisskissbankbank.com/,product,Paris
+KissKissBankBank,https://www.kisskissbankbank.com/,product,Paris
 Kuartz,https://www.kuartz.fr/,agency,Nantes
 Kundigo,http://kundigo.pro/,agency,Chatou
 Labacar,http://labacar.com/,agency,Joinville-le-Pont
-Le Wagon,http://www.lewagon.com/,bootcamp,"Paris, Lille, Bordeaux, Nantes, Marseille, Lyon"
+Le Wagon,https://www.lewagon.com/,bootcamp,"Paris, Lille, Bordeaux, Nantes, Marseille, Lyon"
 LeCollectionist,https://www.lecollectionist.com/,product,Paris
 Leikir web,https://web.leikir.io/,agency,Paris
 Lesportecles,https://www.lesportecles.com/,product,Strasbourg
 Level UP Solutions,https://levups.com/,agency,Remote
 Libertrip,https://www.libertrip.com/,product,Lille
 Lifen,https://www.lifen.fr/,product,Paris
+Lita,https://fr.lita.co/,product,Paris
 LiveMentor,https://www.livementor.com/,product,Paris
 Livestorm,https://livestorm.co/,product,Paris
 Locale,https://www.localeapp.com/,product,Lyon
 Localers,https://www.localers.com/,product,Paris
-LoGeek,http://www.logeek.fr,agency + product,Champdolent
-LunaWeb,http://www.lunaweb.fr/,agency,Rennes
+LoGeek,https://www.logeek.fr,agency + product,Champdolent
+LunaWeb,https://www.lunaweb.fr/,agency,Rennes
 Lunchr,https://www.lunchr.co/,product,Montpellier
-MediaTech Solutions,http://www.mediatech-solutions.com/,product,Paris
+MediaTech Solutions,https://www.mediatech-solutions.com/,product,Paris
 misterb&b,https://www.misterbandb.com/,product,Paris
 moduloTech,http://www.modulotech.fr/,product,Paris
 Moodwork,https://moodwork.co/,product,Paris
 Myeggbox,https://www.myeggbox.com/,product,Lille
 noCRM.io,https://youdontneedacrm.com/,product,Paris
-Novelys,http://www.novelys.com/,agency,Strasbourg
+Novelys,https://www.novelys.com/,agency,Strasbourg
 Numa,https://numa.co/,incubator,Paris
 OnePark,https://www.onepark.fr/,product,Paris
 Ouvrages,https://ouvrages.io/,agency,Clermont-Ferrand
@@ -105,43 +105,44 @@ Plezi,https://www.plezi.co/,product,Paris
 Plume,https://www.plume-app.co/,product,Paris
 poll&roll,https://www.pollandroll.com/,product,Bordeaux
 Predilex,https://predilex.io/,product,Paris
-Prium Solutions,http://prium-solutions.com/,agency,Paris
+Prium Solutions,https://prium-solutions.com/,agency,Paris
 Retails Reload,https://retailreload.com/,product,Boulogne-Billancourt
+Samboat,https://www.samboat.fr/,product,Paris
 Scalingo,https://scalingo.com,product,Strasbourg
 Servebox,https://servebox.com,agency,Aix-en-Provence
 Shipup,https://www.shipup.co/,product,Paris
 Shopmium,https://www.shopmium.com/,product,Paris
 Silicon Salad,http://www.siliconsalad.com,agency,Lille
-Simplon.co,http://simplon.co/,bootcamp,Montreuil
+Simplon.co,https://simplon.co/,bootcamp,Montreuil
 Simundia,https://www.simundia.com/,product,Paris
 Skello,https://www.skello.io/,product,Paris
 Snapshift,https://snapshift.co/,product,Paris
-SociAddict,http://www.sociaddict.com/,agency,Paris
+SociAddict,https://www.sociaddict.com/,agency,Paris
 Speaken,https://speaken.com/,product,Paris
 Sqreen,https://www.sqreen.io/,product,Paris
 Steeple,https://www.steeple.fr/,product,Rennes
 Stuart,https://stuart.com/,product,"Paris, Lyon"
-Studio HB,http://www.studio-hb.com/,agency,Lyon
-Studio Melipone,http://www.studiomelipone.eu/,agency,Paris
+Studio HB,https://www.studio-hb.com/,agency,Lyon
+Studio Melipone,https://www.studiomelipone.eu/,agency,Paris
 Study Advisor,https://www.studyadvisor.fr/,product,Paris
 Synbioz,https://www.synbioz.com/,agency,"Lille, Nantes, Paris"
 talent.io,https://www.talent.io,product,"Paris, Berlin, London"
-Teezily,http://teezily.com/,product,Paris
+Teezily,https://www.teezily.com/,product,Paris
 The Social Client,http://thesocialclient.com/,agency,Paris
-Tilkee,http://www.tilkee.fr,product,Lyon
-Tinci,http://www.tinci.fr/,agency,Paris
+Tilkee,https://www.tilkee.fr,product,Lyon
+Tinci,https://www.tinci.fr/,agency,Paris
 Touch & Sell,https://www.touch-sell.com/,product,Paris
 Trainline,https://www.trainline.eu/,product,Paris
 Traktor,https://tracktor.fr/,product,Paris
-Tymate,http://tymate.com/,agency,Lille
-Vodeclic,http://vodeclic.com/,product,Levallois
+Tymate,https://tymate.com/,agency,Lille
+Vodeclic,https://www.vodeclic.com/,product,Levallois
 Wecasa,https://www.wecasa.fr/,product,Paris
 Welcome to the Jungle,https://www.welcometothejungle.co/,product,Paris
 WeSave,https://www.wesave.fr,product,Paris
-What A Nice Place,http://whataniceplace.com/,product,Lille
+What A Nice Place,https://whataniceplace.com/,product,Lille
 Winddle,https://www.winddle.com/,product,Paris
 Wizville,https://wizville.fr/,product,Paris
-Wizypay,http://wizypay.com/,product,Paris
+Wizypay,https://wizypay.com/,product,Paris
 Yes 'N' YOU,https://www.yesnyoulearning.com/,product,Paris
 Yespark,https://www.yespark.fr/,product,Paris
 Youboox,https://www.youboox.fr/,product,Paris

--- a/frenchrubyshops.csv
+++ b/frenchrubyshops.csv
@@ -17,7 +17,7 @@ Capsens,https://agence.capsens.eu/,product,Paris
 Captain Contrat,https://www.captaincontrat.com/,product,Paris
 Captive,https://captive.fr/,agency,Paris
 Cheerz,https://www.cheerz.com/,product,Paris
-Clic2Buy,https://www.click2buy.com/,product,Lille
+Click2Buy,https://www.click2buy.com/,product,Lille
 Codeur,https://www.codeur.com,product,Remote
 Coinhouse,https://www.coinhouse.com/,product,Paris
 Colisweb,https://www.colisweb.com/fr,product,Lille

--- a/frenchrubyshops.csv
+++ b/frenchrubyshops.csv
@@ -68,7 +68,7 @@ Kactus,https://www.kactus.com/,product,Paris
 Kerala Ventures,https://www.kerala.vc/,product,Paris
 Key-Live,https://www.keley-live.com/,agency,Paris
 Keycoopt,https://www.keycoopt.com/,product,Lille
-KissKissBankBank,https://www.kisskissbankbank.com/,product,Paris
+KissKissBankBank & Co,https://www.kisskissbankbank.com/,product,Paris
 Kuartz,https://www.kuartz.fr/,agency,Nantes
 Kundigo,http://kundigo.pro/,agency,Chatou
 Labacar,http://labacar.com/,agency,Joinville-le-Pont


### PR DESCRIPTION
- Add Lita
- Rename Drivy to Getaround
- Rename Clic2Buy to Click2Buy
- Rename Boaterfly to Samboat
- Rename KissKissBankBank to KissKissBankBank & Co
- Use canonical (mostly https) URLs when URL was different