### PR TITLE
Add Ville de Paris with new 'public' category

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please respect the following conventions:
 * Companies are sorted by alphabetical name
 * Respect naming for cities already listed: `Saint-Étienne` and not `St Étienne` or `Saint Étienne`
 
-Available categories: `agency, bootcamp, editor, product`.
+Available categories: `agency, bootcamp, editor, product, public`.
 
 Categories are not set in stone, open an issue if you want to add one.
 

--- a/frenchrubyshops.csv
+++ b/frenchrubyshops.csv
@@ -136,6 +136,7 @@ Touch & Sell,https://www.touch-sell.com/,product,Paris
 Trainline,https://www.trainline.eu/,product,Paris
 Traktor,https://tracktor.fr/,product,Paris
 Tymate,https://tymate.com/,agency,Lille
+Ville de Paris,https://www.paris.fr/,public,Paris
 Vodeclic,https://www.vodeclic.com/,product,Levallois
 Wecasa,https://www.wecasa.fr/,product,Paris
 Welcome to the Jungle,https://www.welcometothejungle.co/,product,Paris


### PR DESCRIPTION
Hi, thanks for the repo. I took the liberty to add a `public` category as **Ville de Paris** does not seem to fit in `agency`, `bootcamp`, `editor`, `product`.